### PR TITLE
Don't link compiler main() into capnp-lib

### DIFF
--- a/third_party/capnproto/BUILD
+++ b/third_party/capnproto/BUILD
@@ -32,7 +32,7 @@ cc_library(
         "c++/src/capnp/**/*.c++",
     ], exclude = [
         "c++/src/capnp/compiler/capnp.c++",
-        "c++/src/capnp/compiler/capnp-c++.c++",
+        "c++/src/capnp/compiler/capnpc-c++.c++",
         "c++/src/capnp/compiler/capnpc-capnp.c++",
         "c++/src/capnp/test-util.c++",
         "c++/src/capnp/**/*-test.c++",


### PR DESCRIPTION
Fix for issue where capnproto compiler main() func is linked into capnp-lib. The cause is a 1-char misspelling in the glob excludes which isn't excluding "compiler/capnpc-c++.c++".
